### PR TITLE
Potential fix for code scanning alert no. 5: Flask app is run in debug mode

### DIFF
--- a/web_application/backend.py
+++ b/web_application/backend.py
@@ -796,4 +796,5 @@ def get_code_stats(code: str, language: str) -> dict:
 
 
 if __name__ == '__main__':
-    app.run(debug=True, threaded=True)
+    debug_mode = os.environ.get('FLASK_DEBUG', '').lower() in ('1', 'true', 'yes')
+    app.run(debug=debug_mode, threaded=True)


### PR DESCRIPTION
Potential fix for [https://github.com/Joshua-Ludolf/SillyVisualizer/security/code-scanning/5](https://github.com/Joshua-Ludolf/SillyVisualizer/security/code-scanning/5)

In general, Flask applications should not hard-code `debug=True` in `app.run` for code that might ever be used in production. Instead, debug mode should be disabled by default and optionally enabled via configuration (environment variables, config files, or a separate development runner).

The best fix here, without changing existing functionality for developers, is to remove the hard-coded `debug=True` and make debug mode conditional on an environment variable such as `FLASK_DEBUG`. This keeps the behavior configurable: in development, developers can set `FLASK_DEBUG=1` (or `true`) and still get debug mode; in production, the environment remains unset or set to `0`, and the server will run with debugging disabled. We can implement this entirely within `web_application/backend.py` by importing `os` (already imported on line 3) and using `os.environ.get` in the `if __name__ == '__main__':` block. Specifically, we will replace line 799 with a version that computes `debug` from `FLASK_DEBUG` and passes that boolean to `app.run`, keeping `threaded=True` unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
