### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/web_application/backend.py
+++ b/web_application/backend.py
@@ -629,14 +629,14 @@ def visualize_code():
             app.logger.error(f"Traceback: {traceback.format_exc()}")
             return jsonify({
                 'error': 'Visualization generation failed',
-                'details': str(viz_error)
+                'details': 'An internal error occurred during visualization generation.'
             }), 500
     
     except Exception as e:
         app.logger.error(f"Request processing error: {str(e)}")
         return jsonify({
             'error': 'Request processing failed',
-            'details': str(e)
+            'details': 'An internal error occurred while processing the request.'
         }), 400
 
 def _get_node_color(node_type: str) -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/Joshua-Ludolf/SillyVisualizer/security/code-scanning/3](https://github.com/Joshua-Ludolf/SillyVisualizer/security/code-scanning/3)

In general, to fix this class of issue you should avoid sending detailed exception messages or stack traces back to the client. Instead, log the full details on the server (including traceback) and return a generic, user-friendly error message. If you need to surface more specific information to clients, use controlled, predefined error codes or messages that do not include raw exception text.

For this specific code, the best minimal fix without changing existing functionality is to replace the use of `str(viz_error)` in the JSON response with a generic message that does not depend on the exception object. The logging behavior can stay as-is so that developers still see the full error and traceback in server logs. Concretely:
- In `visualize_code`, inside the inner `except Exception as viz_error:` block (around lines 627–633), keep the logging lines.
- Change the `details` field in the returned JSON from `str(viz_error)` to a static, generic description such as `"An internal error occurred during visualization generation."` or a similarly neutral phrase.
- The outer `except Exception as e:` block at lines 635–640 has the same pattern (`'details': str(e)`). For consistency and to avoid similar leaks there, also change that `details` value to a generic message like `"An internal error occurred while processing the request."`.

No new imports or helper methods are necessary; the change is limited to the error JSON payloads in `web_application/backend.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
